### PR TITLE
fix bug: client->state not set

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -839,6 +839,7 @@ static void esp_mqtt_task(void *pv)
 
                 if (!client->config->auto_reconnect) {
                     client->run = false;
+                    client->state = MQTT_STATE_UNKNOWN;
                     break;
                 }
                 if (platform_tick_get_ms() - client->reconnect_tick > client->wait_timeout_ms) {


### PR DESCRIPTION
If auto_reconnect is disabled, client->state won't be setted in MQTT_STATE_WAIT_TIMEOUT state, which results in an error if esp_mqtt_client_start() is called.